### PR TITLE
댓글리스트 리스트사이즈나 브라우저 뷰포트에 따라 여러번 호출되는 이슈 수정

### DIFF
--- a/src/app/components/comment/CommentList.tsx
+++ b/src/app/components/comment/CommentList.tsx
@@ -111,7 +111,7 @@ const CommentList = ({parentId, isCreateRecomment, setIsCreateRecomment}: TComme
             const data = await response.json();
 
             setComments(prevComments => [...prevComments, ...data.result.content]);
-            setPage(prevPage => prevPage + 1);
+            setPage(pageToFetch + 1);
             // API 응답에 'hasMore' 속성이 있다고 가정하고 업데이트합니다.
             if(parseInt(data.result.page, 10) >= parseInt(data.result.totalPages,10) -1 )setHasMore(false);
             if(!parentId){
@@ -123,7 +123,7 @@ const CommentList = ({parentId, isCreateRecomment, setIsCreateRecomment}: TComme
         } finally {
             setLoading(false);
         }
-    }, [page, loading, hasMore, parentId, filter]);
+    }, [loading, hasMore, parentId, filter, planId]);
 
     // Intersection Observer를 설정하여 무한 스크롤을 구현합니다.
     useEffect(() => {
@@ -148,7 +148,7 @@ const CommentList = ({parentId, isCreateRecomment, setIsCreateRecomment}: TComme
                 observer.unobserve(currentObserverTarget);
             }
         };
-    }, [fetchComments]); // fetchComments, hasMore, loading이 변경될 때마다 이펙트를 다시 실행합니다.
+    }, [fetchComments, hasMore, loading, page]); // fetchComments, hasMore, loading이 변경될 때마다 이펙트를 다시 실행합니다.
 
     useEffect(() => {
         setComments([]);


### PR DESCRIPTION
  문제점

   1. 상태값 불일치 문제: IntersectionObserver의 콜백 함수가 오래된 page, hasMore, loading 상태 값을 계속 사용하고 있었습니다. 이로 인해 컴포넌트의 실제 상태와 다른 값으로 fetchComments 함수가 호출되어, 동일한 페이지의 댓글을 여러 번 불러오는 버그가 발생했습니다.
   2. 비효율적인 Observer 재생성: 댓글을 불러올 때마다 fetchComments 함수가 새로 생성되고, 그에 따라 IntersectionObserver도 계속해서 재생성되었습니다. 이는 불필요한 리소스 낭비를 유발했습니다.
   3. 페이지 번호 관리의 잠재적 오류: setPage(prevPage => prevPage + 1)와 같이 이전 상태에 의존하여 페이지 번호를 업데이트하는 방식은, 네트워크 요청이 순서대로 처리되지 않을 경우 페이지 번호가 꼬일 수 있는 잠재적 위험이 있었습니다.

  해결 방법

   1. `IntersectionObserver`의 의존성 배열 수정: IntersectionObserver를 생성하는 useEffect의 의존성 배열에 [fetchComments, hasMore, loading, page]를 추가했습니다. 이렇게 함으로써 page, hasMore, loading 상태가 변경될 때마다 IntersectionObserver가 최신 상태를 반영하여 재생성되도록 하여, 항상 정확한 상태 값으로 댓글을 요청하게 만들었습니다.
   2. `fetchComments` 함수 안정화: fetchComments 함수의 useCallback 의존성 배열에서 자주 변경되는 page 상태를 제거했습니다. 이로 인해 fetchComments 함수가 불필요하게 재생성되는 것을 방지하여 성능을 개선했습니다.
   3. 페이지 번호 업데이트 방식 변경: setPage(pageToFetch + 1)와 같이, 현재 불러온 페이지 번호(pageToFetch)를 기준으로 다음 페이지 번호를 명확하게 설정하도록 변경하여 잠재적인 오류 발생 가능성을 제거했습니다.