### PR TITLE
댓글 상태 반영 및 답글 중복 오류 수정

### DIFF
--- a/src/app/components/comment/CommentItem.tsx
+++ b/src/app/components/comment/CommentItem.tsx
@@ -9,9 +9,10 @@ import axios from "axios";
 type TProps = TComment & {
     setComments: React.Dispatch<SetStateAction<TComment[]>>;
     isLogin: boolean;
+    onReplyCreated: (parentCommentId: string) => void;
 }
 
-const CommentItem = ({commentId, profileImage, nickName, content, likesCount, isLiked, parentId, childrenCount, ownership, setComments, isLogin}:TProps) => {
+const CommentItem = ({commentId, profileImage, nickName, content, likesCount, isLiked, parentId, childrenCount, ownership, setComments, isLogin, onReplyCreated}:TProps) => {
 
     const [isExpaneded, setIsExpanded] = useState(false);
     const [isShowOptions, setIsShowOptions] = useState(false);
@@ -113,7 +114,7 @@ const CommentItem = ({commentId, profileImage, nickName, content, likesCount, is
                 {
                     isExpaneded && 
                         <div className={style.re_comment_area}>
-                            <CommentList parentId={commentId} setIsCreateRecomment={setIsCreateRecomment} isCreateRecomment={isCreateRecomment} isLogin={isLogin}/>
+                            <CommentList parentId={commentId} setIsCreateRecomment={setIsCreateRecomment} isCreateRecomment={isCreateRecomment} isLogin={isLogin} onReplyCreated={onReplyCreated}/>
                         </div>
                 }
                 {  ownership === "MINE" && <button type="button" className={style.option_btn} onClick={() => setIsShowOptions(!isShowOptions)}><span className="blind">설정</span></button>}


### PR DESCRIPTION
  1. 댓글 중복 현상

   * 문제점:
       * 답글을 작성하면 댓글이 중복으로 표시되었습니다.
   * 해결 방법:
       * 데이터 로딩 함수(fetchComments)의 의존성이 잘못 설정되어, 불필하게 함수가 재실행되고 전체 댓글 목록을 다시 불러오는 것이 원인이었습니다.
       * useCallback으로 감싸진 fetchComments 함수의 의존성 배열을 수정하여, 함수가 안정적으로 유지되도록 변경했습니다. 이를 통해 불필요한 재실행을 막아 문제의 근본 원인을 해결했습니다.
       * 추가로, React 목록 렌더링의 기본 원칙에 따라 각 댓글 항목(CommentItem)에 고유한 key 값을 부여하여 렌더링 성능과 안정성을 높였습니다.

  2. 답글 수 즉시 미반영

   * 문제점: 답글이 없는 댓글에 첫 답글을 작성해도, 부모 댓글의 '답글' 버튼이 '답글 1'로 즉시 변경되지 않았습니다.
   * 해결 방법:
       * 답글이 성공적으로 작성되었을 때, 그 정보를 부모 댓글에 전달하는 콜백 함수(onReplyCreated)를 구현했습니다.
       * 이 함수를 통해 자식 컴포넌트(답글 목록)에서 일어난 상태 변화를 부모 컴포넌트(댓글 아이템)에 알리고, 부모의 답글 수(childrenCount)를 즉시 업데이트하도록 하여 버튼 내용이 바로 변경되게 수정했습니다.
---

  원래 코드의 문제점: '임시 댓글'의 정보 부족

   * 원인: 기존 코드는 답글을 작성하면, 서버의 응답을 기다리지 않고 화면에 바로 보여주기 위해 '임시 댓글'을 만들어 목록의 맨 앞에 추가했습니다. (낙관적 업데이트)
   * 문제: 그런데 이 '임시 댓글'을 만들 때, API가 반환해준 최소한의 정보(commentId, content)만 사용하고, 사용자의 프로필 이미지(`profileImage`)나 닉네임(`nickName`) 같은 정보는 포함하지 않았습니다.
   * 결과: 따라서 댓글을 달면, 프로필 이미지가 없는 불완전한 '임시 댓글'이 먼저 보였던 것입니다.

  수정된 코드의 작동 방식: '전체 새로고침'

   * 해결: 댓글 중복, 깜빡임 등의 문제를 해결하는 과정에서, 저는 이 '낙관적 업데이트' 방식을 버리고 댓글 작성 후 서버에서 전체 댓글 목록을 다시 가져와 화면 전체를 새로고침하는 방식으로 변경했습니다.
   * 결과: 이제는 댓글을 작성하면, 서버로부터 프로필 이미지를 포함한 완전한 정보의 댓글 목록을 새로 받아와 화면에 표시합니다. 따라서 사용자의 프로필 이미지가 정상적으로 즉시 표시되는 것입니다.

---

https://github.com/user-attachments/assets/49a9b18d-76be-4708-bbe5-2a018f8b4557