### PR TITLE
위치 장소 사진 반영

### DIFF
--- a/src/app/components/create/CreateSearchList.module.scss
+++ b/src/app/components/create/CreateSearchList.module.scss
@@ -7,11 +7,6 @@
     width: 417px;
     margin: 121px 0 0;
 
-    @media (max-width: 769px) {
-        width: 100%;
-        margin: 73px 0 0;
-    }
-
     .search_wrap {
         display: flex;
         align-items: center;
@@ -19,10 +14,6 @@
         padding: 10px 20px;
         border: 1px solid #e2e2e2;
         border-radius: 40px;
-
-        @media (max-width: 769px) {
-            width: calc(100% - 64px);
-        }
 
         &::before {
             flex-shrink: 0;
@@ -49,11 +40,6 @@
         margin: 20px 32px 20px 0;
         flex-direction: column;
         overflow-y: auto;
-
-        @media (max-width: 769px) {
-            max-height: calc(100vh - 210px);
-            margin: 20px 0;
-        }
 
         .loading {
             margin: 20px 0;
@@ -135,7 +121,7 @@
                 }
             }
 
-            .category {
+            .category{
                 display: flex;
                 align-items: center;
                 gap: 2px;


### PR DESCRIPTION
기존에 저장된 플랜을 불러올 때, 장소에 이미지 URL(thumbnailImageUrl)이 없는 경우, 장소의 이름(locationName)으로 Tour API를 다시 호출하여 해당 이미지 URL을 가져와 채워 넣도록 수정되었습니다.